### PR TITLE
Make MQTT publishing resilient to internet connection outage

### DIFF
--- a/beelogger2.py
+++ b/beelogger2.py
@@ -205,10 +205,13 @@ def run():
 					payload = json.dumps(measurement_data)
 
 					# Publish data to MQTT Backend
-					backend = mqtt.Client(client_id=client_id, clean_session=True)
-					backend.connect(mqtt_broker)
-					backend.publish(mqtt_topic, payload)
-					backend.disconnect()
+					try:
+						backend = mqtt.Client(client_id=client_id, clean_session=True)
+						backend.connect(mqtt_broker)
+						backend.publish(mqtt_topic, payload)
+						backend.disconnect()
+					except Exception as ex:
+						logging.error('Failed publishing measurements to MQTT: {ex}'.format(ex=ex))
 
 					# Write data to CSV file
 					writer.writerow( (datum, uhrzeit) + measurement_tuple )


### PR DESCRIPTION
Dear Markus,

the other [Markus](https://community.hiveeyes.org/u/mmeier) reported having intermittent problems with his internet connection, so we tried to make the measurement and publishing program more robust against internet connection outage.

With kind regards,
Andreas.
